### PR TITLE
update the install ref to include chart repo name

### DIFF
--- a/pkg/util/helmutil/job.go
+++ b/pkg/util/helmutil/job.go
@@ -64,7 +64,7 @@ func GenerateHelmInstallJob(application sdsapi.SDSApplicationSpec) batchv1.Job {
 	commandString += "/helm repo update && "
 	commandString += "/helm install --tiller-namespace " + packageManager.Spec.Namespace + " --name " + application.Name
 	commandString += " --namespace " + application.Namespace + " --values /helm.values "
-	commandString += application.Chart.Name
+	commandString += application.Chart.Repository.Name + "/" + application.Chart.Name
 	commandString += ""
 
 	jobSpec := batchv1.JobSpec{


### PR DESCRIPTION
Currently when attempting to run `helm install` the chart is not found because only the chart name is provided and it needs the the chart repo name as well.