### PR TITLE
Update log appearance for application controller

### DIFF
--- a/pkg/controllers/sdsapplication/controller.go
+++ b/pkg/controllers/sdsapplication/controller.go
@@ -92,14 +92,14 @@ func NewSDSApplicationController(config *rest.Config) (output *SDSApplicationCon
 	sharedInformer.AddEventHandlerWithResyncPeriod(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(obj)
-			logger.Infof("Add")
+			logger.Infof("add key %v", key)
 			if err == nil {
 				queue.Add(key)
 			}
 		},
 		UpdateFunc: func(old interface{}, new interface{}) {
 			key, err := cache.MetaNamespaceKeyFunc(new)
-			logger.Infof("Update")
+			logger.Infof("update key %v", key)
 			if err == nil {
 				queue.Add(key)
 			}
@@ -108,7 +108,7 @@ func NewSDSApplicationController(config *rest.Config) (output *SDSApplicationCon
 			// IndexerInformer uses a delta queue, therefore for deletes we have to use this
 			// key function.
 			key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
-			logger.Infof("Delete")
+			logger.Infof("delete key %v", key)
 			if err == nil {
 				queue.Add(key)
 			}
@@ -125,5 +125,5 @@ func NewSDSApplicationController(config *rest.Config) (output *SDSApplicationCon
 		cmaGRPCClient: cmaGRPCClient,
 	}
 	output.SetLogger()
-	return
+	return output, nil
 }


### PR DESCRIPTION
The existing log result has two issues:
- it provides little information to a reader of the log message
- it doesn't follow go community conventions for log messages

To improve the message this adds information to the message and
sets the first letter to lower case. Incidentally, this also adds return
values to the adjacent bare return.

closes #24

Signed-off-by: Mark Ayers <mark@philoserf.com>

**NOTE for Reviewers**: I had considered removing the log message. I am not certain that adding more context to the message improves what will still be a potentially long set of log messages. See the example in the referenced issue for an example.