### PR TITLE
Add logging app ownerref

### DIFF
--- a/pipeline.yaml
+++ b/pipeline.yaml
@@ -10,5 +10,13 @@ deployments:
     timeout: 600
     retries: 2
     release: cma-operator
+    test:
+      values:
+        - key: bundles.metrics
+          value: "false"
+        - key: bundles.nginxk8smon
+          value: "false"
+        - key: bundles.nodelabelbot5000
+          value: "false"
 prod:
   doDeploy: none

--- a/pkg/controllers/sds-cluster/controller.go
+++ b/pkg/controllers/sds-cluster/controller.go
@@ -318,6 +318,16 @@ func (c *SDSClusterController) handleClusterReady(clusterName string, clusterInf
 				},
 			}
 
+			// set owner reference
+			loggingPackageManager.OwnerReferences = []v1.OwnerReference{
+				*v1.NewControllerRef(freshCopy,
+					runtimeSchema.GroupVersionKind{
+						Group: api.SchemeGroupVersion.Group,
+						Version: api.SchemeGroupVersion.Version,
+						Kind: "SDSCluster",
+					}),
+			}
+
 			loggingPackageManager.Name = loggingPackageManager.Spec.Name + "-" + clusterName
 			loggingPackageManager.Namespace = viper.GetString(KubernetesNamespaceViperVariableName)
 

--- a/pkg/controllers/sds-cluster/controller.go
+++ b/pkg/controllers/sds-cluster/controller.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	runtimeSchema "k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 const (
@@ -358,6 +359,17 @@ func (c *SDSClusterController) handleClusterReady(clusterName string, clusterInf
 					},
 				},
 			}
+
+			// set owner reference
+			loggerApplication.OwnerReferences = []v1.OwnerReference{
+				*v1.NewControllerRef(freshCopy,
+					runtimeSchema.GroupVersionKind{
+						Group: api.SchemeGroupVersion.Group,
+						Version: api.SchemeGroupVersion.Version,
+						Kind: "SDSCluster",
+					}),
+			}
+
 			loggerApplication.Name = clusterLoggingApplicationName
 			loggerApplication.Namespace = viper.GetString(KubernetesNamespaceViperVariableName)
 			newLoggerApplication, err := c.client.CmaV1alpha1().SDSApplications(viper.GetString(KubernetesNamespaceViperVariableName)).Create(loggerApplication)


### PR DESCRIPTION
adding owner reference to the logging application and package manager so that it will be cleaned up properly on cluster deletion. 